### PR TITLE
fix: add blank space to fix linting issue

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -592,7 +592,7 @@ def apply_price_discount_rule(pricing_rule, item_details, args):
 
 		field = frappe.scrub(apply_on)
 		if pricing_rule.apply_discount_on_rate and item_details.get("discount_percentage"):
-			# Apply discount on discounted rate
+			# Apply discount on discounted rate, test
 			item_details[field] += (100 - item_details[field]) * (pricing_rule.get(field, 0) / 100)
 		elif args.price_list_rate:
 			value = pricing_rule.get(field, 0)


### PR DESCRIPTION
Issue: Incorrect Discount Display on UI (Correct After Save) When Multiple Pricing Rules Apply

Previously, discount values were not showing correctly in the grid when a new item was added.
This PR resolves the issue so that the correct discount values appear immediately.

# Before
![before_full_low](https://github.com/user-attachments/assets/1b4cd5de-a089-412c-b0c1-0c6d2c9a5716)
# After
![Recording 2025-10-02 223600_low](https://github.com/user-attachments/assets/bf1ec85d-a1d2-4a4b-a282-455ef1b2b0c1)

